### PR TITLE
fix(fine-tuning): unblock addDeliverable after penalty-settle

### DIFF
--- a/contracts/fine-tuning/FineTuningAccount.sol
+++ b/contracts/fine-tuning/FineTuningAccount.sol
@@ -660,10 +660,11 @@ library AccountLibrary {
             revert DeliverableAlreadyExists(id);
         }
 
-        // MED-4 FIX: Enforce serial task execution
-        // BUSINESS RULE: Tasks must be completed sequentially
-        // Only allow new deliverable if previous one is acknowledged or no deliverables exist
-        // This prevents adding new tasks while previous ones are still pending
+        // Enforce serial task execution: previous deliverable must be in a terminal state.
+        // Terminal = acknowledged (normal flow) OR settled (penalty-settle path completed
+        // without ack). Without the settled branch, a settle-before-ack race permanently
+        // deadlocks the (user, provider) pair: acknowledgeDeliverable and abandonDeliverable
+        // both revert once settled=true, and this gate would refuse any further deliverable.
         if (account.deliverablesCount > 0) {
             // Get the most recent deliverable ID
             uint latestIndex;
@@ -676,7 +677,8 @@ library AccountLibrary {
             }
 
             string memory latestId = account.deliverableIds[latestIndex];
-            if (!account.deliverables[latestId].acknowledged) {
+            Deliverable storage latest = account.deliverables[latestId];
+            if (!latest.acknowledged && !latest.settled) {
                 revert PreviousDeliverableNotAcknowledged(latestId);
             }
         }
@@ -698,11 +700,11 @@ library AccountLibrary {
             evicted = false;
             evictedId = "";
         } else {
-            // Array is full (20 deliverables), use FIFO eviction strategy
-            // SAFETY: Due to serial task validation above, all older deliverables
-            // must be acknowledged before we can add this new one. Therefore,
-            // the oldest deliverable is guaranteed to be acknowledged.
-            // IMPORTANT: We also check that it's settled to prevent loss of settlement rights.
+            // Array is full (20 deliverables), use FIFO eviction strategy.
+            // SAFETY: the serial-task gate above ensures every older deliverable is in a
+            // terminal state (acknowledged or settled). The explicit !oldest.settled check
+            // below additionally guards against losing settlement rights for an acknowledged
+            // but un-settled deliverable.
             string memory oldestId = account.deliverableIds[account.deliverablesHead];
             Deliverable storage oldest = account.deliverables[oldestId];
 

--- a/test/fine_tuning_serving.spec.ts
+++ b/test/fine_tuning_serving.spec.ts
@@ -568,6 +568,78 @@ describe("Fine tuning serving", () => {
         });
     });
 
+    // Regression: a deliverable left in (settled=true, acknowledged=false) by the
+    // penalty-settle path used to permanently deadlock the (user, provider) pair.
+    // Both acknowledgeDeliverable and abandonDeliverable refuse to transition out
+    // of that state, and addDeliverable's serial-execution gate previously demanded
+    // acknowledged=true. Treating settled as a terminal state in addDeliverable
+    // restores progress without changing the economics of the penalty path.
+    describe("Penalty-settle recovery", () => {
+        const modelRootHash = "0x1234567890abcdef1234567890abcdef12345678";
+        const taskFee = 10;
+        let firstDeliverableId: string;
+
+        beforeEach(async () => {
+            await serving.connect(owner).acknowledgeTEESignerByOwner(provider1Address);
+
+            firstDeliverableId = ethers.hexlify(ethers.randomBytes(32));
+            await serving.connect(provider1).addDeliverable(ownerAddress, firstDeliverableId, modelRootHash);
+
+            // Provider settles without prior ack -> penalty path, deliverable left
+            // in settled=true / acknowledged=false.
+            let verifierInput: VerifierInputStruct = {
+                taskFee,
+                encryptedSecret: "0x",
+                modelRootHash,
+                id: firstDeliverableId,
+                nonce: BigInt(1),
+                user: ownerAddress,
+                signature: "",
+            };
+            verifierInput = await backfillVerifierInput(providerPrivateKey, verifierInput, serving);
+            await serving.connect(provider1).settleFees(verifierInput);
+
+            const stuck = await serving.getDeliverable(ownerAddress, provider1Address, firstDeliverableId);
+            expect(stuck.settled).to.equal(true);
+            expect(stuck.acknowledged).to.equal(false);
+        });
+
+        it("acknowledgeDeliverable still reverts on a settled deliverable", async () => {
+            await expect(
+                serving.acknowledgeDeliverable(provider1Address, firstDeliverableId)
+            ).to.be.revertedWithCustomError(serving, "CannotAcknowledgeSettledDeliverable");
+        });
+
+        it("abandonDeliverable still reverts on a settled deliverable", async () => {
+            await expect(
+                serving.connect(provider1).abandonDeliverable(ownerAddress, firstDeliverableId)
+            ).to.be.revertedWithCustomError(serving, "CannotAbandonSettledDeliverable");
+        });
+
+        it("addDeliverable accepts settled-without-ack as a terminal state and a full lifecycle then succeeds", async () => {
+            const nextId = ethers.hexlify(ethers.randomBytes(32));
+            const nextHash = ethers.hexlify(ethers.randomBytes(32));
+
+            await expect(
+                serving.connect(provider1).addDeliverable(ownerAddress, nextId, nextHash)
+            ).to.emit(serving, "DeliverableAdded");
+
+            await serving.acknowledgeDeliverable(provider1Address, nextId);
+
+            let verifierInput: VerifierInputStruct = {
+                taskFee,
+                encryptedSecret: "0x1234567890abcdef1234567890abcdef12345678",
+                modelRootHash: nextHash,
+                id: nextId,
+                nonce: BigInt(2),
+                user: ownerAddress,
+                signature: "",
+            };
+            verifierInput = await backfillVerifierInput(providerPrivateKey, verifierInput, serving);
+            await expect(serving.connect(provider1).settleFees(verifierInput)).to.emit(serving, "BalanceUpdated");
+        });
+    });
+
     describe("Deliverable Limits", () => {
         // Constants from AccountLibrary contract
         const MAX_DELIVERABLES_PER_ACCOUNT = 20;


### PR DESCRIPTION
## Summary

Fix a contract-level deadlock in the fine-tuning lifecycle where the `(user, provider)` pair becomes permanently locked once `settleFees` runs before `acknowledgeDeliverable`.

The penalty-settle path is a designed branch — provider gets a discounted fee and never delivers the decryption key — but the resulting `settled=true / acknowledged=false` state has no exit:

- `acknowledgeDeliverable` reverts (`CannotAcknowledgeSettledDeliverable`)
- `abandonDeliverable` reverts (`CannotAbandonSettledDeliverable`)
- `addDeliverable` reverts (`PreviousDeliverableNotAcknowledged`)

The root cause is that `addDeliverable`'s serial-execution gate uses `acknowledged` as a proxy for "previous deliverable in terminal state", but `settled-without-ack` is *also* a designed terminal state. Treating both flags as terminal aligns the gate with the actual lifecycle and dissolves the deadlock.

## Change

```diff
- if (!account.deliverables[latestId].acknowledged) {
+ Deliverable storage latest = account.deliverables[latestId];
+ if (!latest.acknowledged && !latest.settled) {
      revert PreviousDeliverableNotAcknowledged(latestId);
  }
```

Also refreshes the FIFO eviction-safety comment, since "oldest is guaranteed acknowledged" no longer holds after the gate relaxation. The standalone \`!oldest.settled\` check at line 710 still independently protects acked-but-unsettled deliverables from silent eviction, so eviction safety is preserved.

## Impact

- **Pure logic change** — no struct fields added, no storage layout impact, safe for in-place upgrade
- **Existing stuck pairs unstick automatically** after upgrade since new bytecode runs against existing storage
- **No new attack surface** — \`acknowledged\` flag still preserved as the "user accepted the model" signal; penalty fee math unchanged; eviction-rights protection unchanged

## Test plan

- [x] \`npx hardhat compile\` clean
- [x] \`npx hardhat test test/fine_tuning_serving.spec.ts\` — all 31 existing tests pass
- [ ] Add regression test covering the deadlock scenario (deliver → settleFees(unacked) → addDeliverable should now succeed)
- [ ] Run \`hardhat upgrade:validate\` against deployed \`FineTuningServing_v1.1\` before deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)